### PR TITLE
Changes to allow compilation under newer C++20 rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,7 +57,13 @@
         "xstddef": "cpp",
         "xstring": "cpp",
         "xtr1common": "cpp",
-        "xutility": "cpp"
+        "xutility": "cpp",
+        "atomic": "cpp",
+        "bit": "cpp",
+        "cctype": "cpp",
+        "clocale": "cpp",
+        "compare": "cpp",
+        "concepts": "cpp"
     },
     "cmake.configureOnOpen": true
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(CppUnitTestFramework)
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output)
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output)
 
-# include(CTest)
-# enable_testing()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(Tests)

--- a/CppUnitTestFramework.hpp
+++ b/CppUnitTestFramework.hpp
@@ -442,7 +442,7 @@ namespace CppUnitTestFramework {
     namespace Assert {
         template <typename TLeft, typename TRight>
         std::optional<AssertException> AreEqual(TLeft&& left, TRight&& right) {
-            bool equal = (left == right);
+            bool equal = static_cast<bool>(left == right);
             if (equal) {
                 return std::nullopt;
             }
@@ -670,11 +670,11 @@ namespace CppUnitTestFramework {
             m_logger00->PushSection(text);
         }
 
-        SectionLock(SectionLock&& other)
+        SectionLock(SectionLock&& other) noexcept
           : m_logger00(std::move(other.m_logger00))
         {}
 
-        SectionLock& operator = (SectionLock&& other) {
+        SectionLock& operator = (SectionLock&& other) noexcept {
             if (m_logger00) {
                 m_logger00->PopSection();
             }
@@ -725,8 +725,8 @@ namespace CppUnitTestFramework {
 
         // In leiu of std::make_array()
         template <typename... TArgs>
-        static constexpr auto make_tags_array(TArgs&&... tags) {
-            return std::array<std::string_view, sizeof...(TArgs)> {
+        static auto make_tags_array(TArgs&&... tags) {
+            return std::vector<std::string_view> {
                 std::forward<TArgs>(tags)...
             };
         }
@@ -769,9 +769,10 @@ namespace CppUnitTestFramework {
         static constexpr std::string_view SourceFile = __FILE__;                                    \
         static constexpr size_t SourceLine = __LINE__;                                              \
         static constexpr std::string_view Name = #TestFixture "::" #TestName;                       \
-        static constexpr auto Tags = make_tags_array(__VA_ARGS__);                                  \
+        static std::vector<std::string_view> Tags;                                                  \
         void Run();                                                                                 \
     };                                                                                              \
+    std::vector<std::string_view> TestCase_##TestName::Tags = make_tags_array(__VA_ARGS__);         \
     CppUnitTestFramework::TestRegistry::AutoReg<TestCase_##TestName> _CPPUTF_NEXT_REGISTRAR_NAME;   \
 }                                                                                                   \
 void TestCase_##TestName::Run()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A single header C++17 unit test framework with a focus on simplicity and quick setup.  It should compile with any C++17 compliant compiler without any additional source or binary dependencies.  Platform specific operations are avoided.
 
 Visual Studio Code Test Adapter: [vscode-cpputf-test-adapter](https://marketplace.visualstudio.com/items?itemName=drleq.vscode-cpputf-test-adapter)  
-Visual Studio 2017 Test Adapter: [CppUnitTestFrameworkTestAdapter](https://marketplace.visualstudio.com/items?itemName=drleq.CppUnitTestFrameworkTestAdapter)
+Visual Studio Test Adapter: [CppUnitTestFrameworkTestAdapter](https://marketplace.visualstudio.com/items?itemName=drleq.CppUnitTestFrameworkTestAdapter)
 
 
 # Quick start

--- a/Tests/SectionTest.cpp
+++ b/Tests/SectionTest.cpp
@@ -100,7 +100,7 @@ namespace CppUnitTestFrameworkTest {
             static constexpr std::string_view SourceFile = __FILE__;
             static constexpr size_t SourceLine = __LINE__;
             static constexpr std::string_view Name = "SectionTest::Nesting";
-            static constexpr auto Tags = make_tags_array();
+            static std::vector<std::string_view> Tags;
 
             void Run() override {
                 CHECK_EQUAL(GetTestLog(), "");
@@ -116,6 +116,7 @@ namespace CppUnitTestFrameworkTest {
                 CHECK_EQUAL(GetTestLog(), "Push Section: Outer\nPush Section: Inner\nPop\nPop\n");
             }
         };
+        std::vector<std::string_view> TestCase_Nesting::Tags = make_tags_array();
         TestRegistry::AutoReg<TestCase_Nesting> s_test_registrar_Nesting;
     }
 
@@ -128,7 +129,7 @@ namespace CppUnitTestFrameworkTest {
             static constexpr std::string_view SourceFile = __FILE__;
             static constexpr size_t SourceLine = __LINE__;
             static constexpr std::string_view Name = "SectionTest::BDD";
-            static constexpr auto Tags = make_tags_array();
+            static std::vector<std::string_view> Tags;
 
             void Run() override {
                 CHECK_EQUAL(GetTestLog(), "");
@@ -156,6 +157,7 @@ Pop
                 );
             }
         };
+        std::vector<std::string_view> TestCase_BDD::Tags = make_tags_array();
         TestRegistry::AutoReg<TestCase_BDD> s_test_registrar_BDD;
     }
 


### PR DESCRIPTION
Essentially, constexpr std::make_array() is impossible on some C++20 compilers at the moment.  Using a non-const std::vector<> instead allows compilation under C++17 and onwards.  I'll add an automatic switch for constexpr arrays when they become possible.